### PR TITLE
Syntax changes/poisson pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ def loss(
     params = eqx.combine(diffable, static)
     expectation = model(params, hists)
     # Poisson NLL of the expectation and observation
-    log_likelihood = evm.loss.PoissonLogLikelihood()(expectation, observation)
+    log_likelihood = evm.pdf.Poisson(lamb=expectation).log_prob(observation)
     # Add parameter constraints from logpdfs
     constraints = evm.loss.get_log_probs(params)
     log_likelihood += evm.util.sum_over_leaves(constraints)

--- a/docs/binned_likelihood.md
+++ b/docs/binned_likelihood.md
@@ -52,10 +52,8 @@ def NLL(dynamic_params, static_params, hists, observation):
     expectations = model(params, hists)
 
     # first product of Eq. 1 (Poisson term)
-    log_likelihood = evm.loss.PoissonLogLikelihood()
-    loss_val = log_likelihood(
-        expectation=evm.util.sum_over_leaves(expectations),
-        observation=observation,
+    loss_val = evm.pdf.Poisson(lamb=evm.util.sum_over_leaves(expectations)).log_prob(
+        observation
     )
 
     # second product of Eq. 1 (constraint)

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ def loss(
     params = eqx.combine(diffable, static)
     expectation = model(params, hists)
     # Poisson NLL of the expectation and observation
-    log_likelihood = evm.loss.PoissonLogLikelihood()(expectation, observation)
+    log_likelihood = evm.pdf.Poisson(expectation).log_prob(observation)
     # Add parameter constraints from logpdfs
     constraints = evm.loss.get_log_probs(params)
     log_likelihood += evm.util.sum_over_leaves(constraints)

--- a/examples/grad_nll.py
+++ b/examples/grad_nll.py
@@ -4,16 +4,13 @@ from model import hists, model, observation
 
 import evermore as evm
 
-log_likelihood = evm.loss.PoissonLogLikelihood()
-
 
 @eqx.filter_jit
 def loss(model, hists, observation):
     expectations = model(hists)
     constraints = evm.loss.get_log_probs(model)
-    loss_val = log_likelihood(
-        expectation=evm.util.sum_over_leaves(expectations),
-        observation=observation,
+    loss_val = evm.pdf.Poisson(lamb=evm.util.sum_over_leaves(expectations)).log_prob(
+        observation,
     )
     # add constraint
     loss_val += evm.util.sum_over_leaves(constraints)

--- a/examples/nll_profiling.py
+++ b/examples/nll_profiling.py
@@ -10,8 +10,6 @@ import evermore as evm
 def fixed_mu_fit(mu: Array) -> Array:
     from model import hists, model, observation
 
-    log_likelihood = evm.loss.PoissonLogLikelihood()
-
     optim = optax.sgd(learning_rate=1e-2)
     opt_state = optim.init(eqx.filter(model, eqx.is_inexact_array))
 
@@ -31,10 +29,9 @@ def fixed_mu_fit(mu: Array) -> Array:
         model = eqx.combine(dynamic_model, static_model)
         expectations = model(hists)
         constraints = evm.loss.get_log_probs(model)
-        loss_val = log_likelihood(
-            expectation=evm.util.sum_over_leaves(expectations),
-            observation=observation,
-        )
+        loss_val = evm.pdf.Poisson(
+            lamb=evm.util.sum_over_leaves(expectations)
+        ).log_prob(observation)
         # add constraint
         loss_val += evm.util.sum_over_leaves(constraints)
         return -2 * jnp.sum(loss_val)

--- a/src/evermore/loss.py
+++ b/src/evermore/loss.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 from jaxtyping import Array, PyTree
 
+from evermore import pdf
 from evermore.custom_types import PDFLike
 from evermore.parameter import Parameter, params_map
 
@@ -25,6 +26,9 @@ def get_log_probs(module: PyTree) -> PyTree:
         prior = param.prior
         if isinstance(prior, PDFLike):
             prior = cast(PDFLike, prior)
+            if isinstance(prior, pdf.Poisson):
+                # expectation for Poisson pdf (x+1)*lambda
+                return prior.log_prob((param.value + 1) * prior.lamb)
             return prior.log_prob(param.value)
         return jnp.array([0.0])
 

--- a/src/evermore/pdf.py
+++ b/src/evermore/pdf.py
@@ -51,7 +51,7 @@ class Poisson(PDF):
             return xlogy(x, lamb) - lamb - gammaln(x + 1)
 
         logpdf_max = _continous_poisson_log_prob(self.lamb, self.lamb)
-        unnormalized = _continous_poisson_log_prob((x + 1) * self.lamb, self.lamb)
+        unnormalized = _continous_poisson_log_prob(x, self.lamb)
         return unnormalized - logpdf_max
 
     def sample(self, key: PRNGKeyArray) -> Array:

--- a/src/evermore/pdf.py
+++ b/src/evermore/pdf.py
@@ -46,13 +46,15 @@ class Normal(PDF):
 class Poisson(PDF):
     lamb: Array = eqx.field(converter=jnp.atleast_1d)
 
-    def log_prob(self, x: Array) -> Array:
+    def log_prob(self, x: Array, normalize: bool = True) -> Array:
         def _continous_poisson_log_prob(x, lamb):
             return xlogy(x, lamb) - lamb - gammaln(x + 1)
 
-        logpdf_max = _continous_poisson_log_prob(self.lamb, self.lamb)
         unnormalized = _continous_poisson_log_prob(x, self.lamb)
-        return unnormalized - logpdf_max
+        if normalize:
+            logpdf_max = _continous_poisson_log_prob(x, x)
+            return unnormalized - logpdf_max
+        return unnormalized
 
     def sample(self, key: PRNGKeyArray) -> Array:
         # this samples only integers, do we want that?

--- a/src/evermore/visualization.py
+++ b/src/evermore/visualization.py
@@ -83,7 +83,7 @@ def convert_tree_to_penzai(tree: PyTree) -> PyTree:
 
 
 def _convert(leaf: Any, cls: Any) -> Any:
-    from penzai import pz
+    from penzai.deprecated.v1 import pz
 
     if isinstance(leaf, cls) and dataclasses.is_dataclass(leaf):
         fields = dataclasses.fields(leaf)

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -15,4 +15,4 @@ def test_Normal():
 def test_Poisson():
     pdf = Poisson(lamb=jnp.array(10))
 
-    assert pdf.log_prob(jnp.array(-0.5)) == pytest.approx(-1.196003)
+    assert pdf.log_prob(jnp.array(5.0)) == pytest.approx(-1.196003)

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -15,4 +15,4 @@ def test_Normal():
 def test_Poisson():
     pdf = Poisson(lamb=jnp.array(10))
 
-    assert pdf.log_prob(jnp.array(5.0)) == pytest.approx(-1.196003)
+    assert pdf.log_prob(jnp.array(5.0)) == pytest.approx(-1.5342636)


### PR DESCRIPTION
The syntax of the Poisson pdf is changed such that it takes the expectation directly (not the parameter value) and can be evaluated at a specific observation.
```python
from evermore.pdf import Poisson

Poisson(lamb=expectation).log_prob(observation)
```
It can take continuous values for the observation as well which `evermore.loss.PoissonLogLikelihood` can not. With the new syntax `PoissonLogLikelihood` should not be necessary anymore.