### PR TITLE
fix toy generation example

### DIFF
--- a/examples/toy_generation.py
+++ b/examples/toy_generation.py
@@ -1,11 +1,16 @@
 import equinox as eqx
 import jax
+import jax.numpy as jnp
 from jaxtyping import Array, PRNGKeyArray
 from model import hists, model, observation
 
 import evermore as evm
 
 key = jax.random.PRNGKey(0)
+
+# set lower and upper bounds for the mu parameter
+model = eqx.tree_at(lambda t: t.mu.lower, model, jnp.array([0.0]))
+model = eqx.tree_at(lambda t: t.mu.upper, model, jnp.array([10.0]))
 
 # generate a new model with sampled parameters according to their constraint pdfs
 toymodel = evm.parameter.sample(model, key)


### PR DESCRIPTION
in the toy generation example the `SPlusBModel` is loaded with the Parameter `mu` having no lower and upper bounds ([SPlusBModel](https://github.com/pfackeldey/evermore/blob/main/examples/model.py#L11)). In order to generate toys from a uniform distribution the parameter needs bounds.
The bounds are now set to lower=0.0 and upper=10.0.
There is no particular reason for why I have chosen these values.