### PR TITLE
[fix] add sum over Poisson.log_prob in loss function

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ def loss(
     params = eqx.combine(diffable, static)
     expectation = model(params, hists)
     # Poisson NLL of the expectation and observation
-    log_likelihood = evm.pdf.Poisson(lamb=expectation).log_prob(observation)
+    log_likelihood = evm.pdf.Poisson(lamb=expectation).log_prob(observation).sum()
     # Add parameter constraints from logpdfs
     constraints = evm.loss.get_log_probs(params)
     log_likelihood += evm.util.sum_over_leaves(constraints)

--- a/docs/binned_likelihood.md
+++ b/docs/binned_likelihood.md
@@ -54,7 +54,7 @@ def NLL(dynamic_params, static_params, hists, observation):
     # first product of Eq. 1 (Poisson term)
     loss_val = evm.pdf.Poisson(lamb=evm.util.sum_over_leaves(expectations)).log_prob(
         observation
-    )
+    ).sum()
 
     # second product of Eq. 1 (constraint)
     constraints = evm.loss.get_log_probs(model)

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ def loss(
     params = eqx.combine(diffable, static)
     expectation = model(params, hists)
     # Poisson NLL of the expectation and observation
-    log_likelihood = evm.pdf.Poisson(expectation).log_prob(observation)
+    log_likelihood = evm.pdf.Poisson(expectation).log_prob(observation).sum()
     # Add parameter constraints from logpdfs
     constraints = evm.loss.get_log_probs(params)
     log_likelihood += evm.util.sum_over_leaves(constraints)

--- a/examples/grad_nll.py
+++ b/examples/grad_nll.py
@@ -9,8 +9,12 @@ import evermore as evm
 def loss(model, hists, observation):
     expectations = model(hists)
     constraints = evm.loss.get_log_probs(model)
-    loss_val = evm.pdf.Poisson(lamb=evm.util.sum_over_leaves(expectations)).log_prob(
-        observation,
+    loss_val = (
+        evm.pdf.Poisson(lamb=evm.util.sum_over_leaves(expectations))
+        .log_prob(
+            observation,
+        )
+        .sum()
     )
     # add constraint
     loss_val += evm.util.sum_over_leaves(constraints)

--- a/examples/nll_fit.py
+++ b/examples/nll_fit.py
@@ -15,8 +15,10 @@ def loss(dynamic_model, static_model, hists, observation):
     model = eqx.combine(dynamic_model, static_model)
     expectations = model(hists)
     constraints = evm.loss.get_log_probs(model)
-    loss_val = evm.pdf.Poisson(evm.util.sum_over_leaves(expectations)).log_prob(
-        observation
+    loss_val = (
+        evm.pdf.Poisson(evm.util.sum_over_leaves(expectations))
+        .log_prob(observation)
+        .sum()
     )
     # add constraint
     loss_val += evm.util.sum_over_leaves(constraints)

--- a/examples/nll_profiling.py
+++ b/examples/nll_profiling.py
@@ -29,9 +29,11 @@ def fixed_mu_fit(mu: Array) -> Array:
         model = eqx.combine(dynamic_model, static_model)
         expectations = model(hists)
         constraints = evm.loss.get_log_probs(model)
-        loss_val = evm.pdf.Poisson(
-            lamb=evm.util.sum_over_leaves(expectations)
-        ).log_prob(observation)
+        loss_val = (
+            evm.pdf.Poisson(lamb=evm.util.sum_over_leaves(expectations))
+            .log_prob(observation)
+            .sum()
+        )
         # add constraint
         loss_val += evm.util.sum_over_leaves(constraints)
         return -2 * jnp.sum(loss_val)


### PR DESCRIPTION
in the calculation of the poisson term of the likelihood function the sum has to be taken before the constraints are added with `loss_val += evm.util.sum_over_leaves(constraints)` because `Poisson.log_prob` returns a multi-dimensional array with the same shape as `observation`

so it has to be
```python
@eqx.filter_jit
def loss(dynamic_model, static_model, hists, observation):
    model = eqx.combine(dynamic_model, static_model)
    expectations = model(hists)
    constraints = evm.loss.get_log_probs(model)
    loss_val = (
        evm.pdf.Poisson(evm.util.sum_over_leaves(expectations))
        .log_prob(observation)
        .sum()
    )
    # add constraint
    loss_val += evm.util.sum_over_leaves(constraints)
    return -jnp.sum(loss_val)
```

changed in the documentation and examples