### PR TITLE
feat: add parameter transformations

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -68,9 +68,8 @@ PDFs
 
 Parameter Boundaries
 
-:   The `lower` and `upper` attributes denote the valid bounds of a parameter. Using `evm.loss.get_boundary_constraints` allows you to extract
-    from a PyTree of parameters if a value if outside of these bounds; if yes it return `jnp.inf` else `0.0`. This return value can be added to
-    the likelihood function in order to _break_ the fit in case a parameter runs out of its bounds.
+:   The `lower` and `upper` attributes denote the valid bounds of a parameter.
+They can be used to e.g. transform a parameter to a constrained space or add penalty terms to the loss function.
 
 
 Freeze a Parameter

--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -33,10 +33,11 @@ parameter = evm.Parameter()
 parameter = evm.Parameter(
     value=1.0,          # default: 0.0
     name="my_param",    # default: None
-    lower=0.0,          # default: -jnp.inf
-    upper=10.0,         # default: +jnp.inf
+    lower=0.0,          # default: None
+    upper=10.0,         # default: None
     prior=None,         # default: None
     frozen=False,       # default: False
+    transform=None,     # default: None
 )
 ```
 
@@ -69,7 +70,8 @@ PDFs
 Parameter Boundaries
 
 :   The `lower` and `upper` attributes denote the valid bounds of a parameter.
-They can be used to e.g. transform a parameter to a constrained space or add penalty terms to the loss function.
+They can be used to e.g. enforce a parameter to only have values in a constrained space or add penalty terms to the loss function.
+More information can be found in <project:#parameter-transformations>.
 
 
 Freeze a Parameter

--- a/docs/tips_and_tricks.md
+++ b/docs/tips_and_tricks.md
@@ -63,6 +63,42 @@ with open("composition.html", "w") as f:
     f.write(contents)
 ```
 
+(parameter-transformations)=
+## Parameter Transformations
+
+evermore provides a set of parameter transformations that can be used to modify the parameter values.
+This can be useful for example to ensure that the parameter values are within a certain range or that they are always positive.
+evermore provides two predefined transformations: [`evm.parameter.MinuitTransform`](#evermore.parameter.MinuitTransform) (for bounded parameters) and [`evm.parameter.SoftPlusTransform`](#evermore.parameter.SoftPlusTransform) (for positive parameters).
+
+
+```{code-cell} ipython3
+import evermore as evm
+import wadler_lindig as wl
+
+
+enforce_positivity = evm.parameter.SoftPlusTransform()
+pytree = {
+    "a": evm.Parameter(2.0, transform=enforce_positivity),
+    "b": evm.Parameter(0.1, transform=enforce_positivity),
+}
+
+# unwrap (or "transform")
+pytree_t = evm.parameter.unwrap(pytree)
+# wrap back (or "inverse transform")
+pytree_tt = evm.parameter.wrap(pytree_t)
+
+wl.pprint(("Original", pytree), width=150, short_arrays=False)
+wl.pprint(("Transformed", pytree_t), width=150, short_arrays=False)
+wl.pprint(("Transformed back / Original", pytree_tt), width=150, short_arrays=False)
+```
+
+Transformations always transform into the unconstrained real space (using [`evm.parameter.unwrap`](#evermore.parameter.unwrap)) and back to the constrained space (using [`evm.parameter.wrap`](#evermore.parameter.wrap)).
+Typically, you would transform your parameters as a first step inside your loss (or model) function.
+Then, a minimizer can optimize the transformed parameters in the unconstrained space. Finally, you can transform them back to the constrained space for further processing.
+
+Custom transformations can be defined by subclassing [`evm.parameter.ParameterTransformation`](#evermore.parameter.ParameterTransformation) and implementing the [`wrap`](#evermore.parameter.ParameterTransformation.wrap) and [`unwrap`](#evermore.parameter.ParameterTransformation.unwrap) methods.
+
+
 ## Parameter Partitioning
 
 For optimization it is necessary to differentiate only against meaningful leaves of the PyTree of `evm.Parameters`.

--- a/examples/model.py
+++ b/examples/model.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import equinox as eqx
 import jax.numpy as jnp
-from jaxtyping import Array, PyTree
+from jaxtyping import Array
 
 import evermore as evm
 
@@ -12,9 +12,6 @@ class SPlusBModel(eqx.Module):
     norm1: evm.NormalParameter
     norm2: evm.NormalParameter
     shape1: evm.NormalParameter
-
-    def __init__(self, hist: PyTree, histw2: PyTree) -> None:
-        evm.util.dataclass_auto_init(self)
 
     def __call__(self, hists: dict) -> dict[str, Array]:
         expectations = {}
@@ -63,14 +60,12 @@ hists = {
     },
 }
 
-hist = hists["nominal"]
-histw2 = {
-    "signal": jnp.array([5]),
-    "bkg1": jnp.array([11]),
-    "bkg2": jnp.array([25]),
-}
-
-model = SPlusBModel(hist, histw2)
+model = SPlusBModel(
+    mu=evm.Parameter(value=0.0, lower=0.0, upper=10.0),
+    norm1=evm.NormalParameter(),
+    norm2=evm.NormalParameter(),
+    shape1=evm.NormalParameter(),
+)
 
 observation = jnp.array([37])
 expectations = model(hists)

--- a/examples/toy_generation.py
+++ b/examples/toy_generation.py
@@ -1,16 +1,11 @@
 import equinox as eqx
 import jax
-import jax.numpy as jnp
 from jaxtyping import Array, PRNGKeyArray
 from model import hists, model, observation
 
 import evermore as evm
 
 key = jax.random.PRNGKey(0)
-
-# set lower and upper bounds for the mu parameter
-model = eqx.tree_at(lambda t: t.mu.lower, model, jnp.array([0.0]))
-model = eqx.tree_at(lambda t: t.mu.upper, model, jnp.array([10.0]))
 
 # generate a new model with sampled parameters according to their constraint pdfs
 toymodel = evm.parameter.sample(model, key)

--- a/src/evermore/loss.py
+++ b/src/evermore/loss.py
@@ -5,10 +5,9 @@ from jaxtyping import Array, PyTree
 
 from evermore import pdf
 from evermore.custom_types import PDFLike
-from evermore.parameter import Parameter, params_map
+from evermore.parameter import Parameter, _params_map
 
 __all__ = [
-    "get_boundary_constraints",
     "get_log_probs",
 ]
 
@@ -29,8 +28,4 @@ def get_log_probs(module: PyTree) -> PyTree:
         return jnp.array([0.0])
 
     # constraints from pdfs
-    return params_map(_constraint, module)
-
-
-def get_boundary_constraints(module: PyTree) -> PyTree:
-    return params_map(lambda p: p.boundary_constraint, module)
+    return _params_map(_constraint, module)

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import jax.numpy as jnp
 import pytest
 
 import evermore as evm
@@ -17,11 +16,3 @@ def test_get_log_probs():
     assert log_probs["a"] == pytest.approx(-0.125)
     assert log_probs["b"] == pytest.approx(0.0)
     assert log_probs["c"] == pytest.approx(0.0)
-
-
-def test_get_boundary_constraints():
-    in_bounds_param = evm.Parameter(value=1.0, lower=0.0, upper=2.0)
-    oob_param = evm.Parameter(value=3.0, lower=0.0, upper=2.0)
-
-    assert evm.loss.get_boundary_constraints(in_bounds_param) == 0.0
-    assert evm.loss.get_boundary_constraints(oob_param) == jnp.inf

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -9,7 +9,6 @@ def test_Parameter():
     assert p.value == 1.0
     assert p.lower == 0.0
     assert p.upper == 2.0
-    assert p.boundary_constraint == 0.0
     assert p.prior is None
 
 
@@ -18,5 +17,4 @@ def test_NormalParameter():
     assert p.value == 1.0
     assert p.lower == 0.0
     assert p.upper == 2.0
-    assert p.boundary_constraint == 0.0
     assert isinstance(p.prior, Normal)


### PR DESCRIPTION
This PR adds parameter transformations, one example is shown in the following:
```python
import evermore as evm
import wadler_lindig as wl

pytree = {
    "a": evm.Parameter(
        2.0, lower=-0.1, upper=2.2, transform=evm.parameter.MinuitTransform()
    ),  # close to upper bound
    "b": evm.Parameter(
        0.1, lower=0.0, upper=1.1, transform=evm.parameter.MinuitTransform()
    ),  # close to lower bound
}

# unwrap (or "transform")
pytree_t = evm.parameter.unwrap(pytree)
# wrap back (or "inverse transform")
pytree_tt = evm.parameter.wrap(pytree_t)

wl.pprint(pytree, width=150, short_arrays=False)
# {
#   'a': Parameter(value=Array([2.], dtype=float32), lower=-0.1, upper=2.2, transform=MinuitTransform()),
#   'b': Parameter(value=Array([0.1], dtype=float32), lower=0.0, upper=1.1, transform=MinuitTransform())
# }

wl.pprint(pytree_t, width=150, short_arrays=False)
# {
#   'a': Parameter(value=Array([0.9721281], dtype=float32), lower=-0.1, upper=2.2, transform=MinuitTransform()),
#   'b': Parameter(value=Array([-0.95824164], dtype=float32), lower=0.0, upper=1.1, transform=MinuitTransform())
# }

wl.pprint(pytree_tt, width=150, short_arrays=False)
# {
#   'a': Parameter(value=Array([1.9999999], dtype=float32), lower=-0.1, upper=2.2, transform=MinuitTransform()),
#   'b': Parameter(value=Array([0.09999997], dtype=float32), lower=0.0, upper=1.1, transform=MinuitTransform())
# }
```

by passing `evm.parameter.MinuitTransform()` to the `transform=` argument of a `evm.Parameter` we can apply that transformation on-the-fly inside a stat. model. This is heavily inspired by https://github.com/danielward27/paramax, but I wanted to have this better integrated with the existing parameters.

To transform a pytree of parameters `evm.parameter.unwrap` can be used, and `evm.parameter.wrap` can be used to transform them back, see example from above.

In addition to `MinuitTransform` (which applies the transformation as defined by Minuit to go from a bounded space to the unbounded space R), I've implemented a `SoftPlusTransformation` which projects a parameter value from R -> R+ (and back). 

In general, parameter transformations need to be bijective and smooth differentiable (this requirement is not necessary for the inverse). Parameter transformations can be defined _per_ parameter, default is `None` (no transformation).

fyi @maxgalli & @felixzinn 

---
Other changes in this PR: 
- some doc string improvements
- simplification of model construction in the examples folder
- dropped the `.boundary_constraint` that was just adding infinity as a penalty to the loss (and thus breaks a fit)
