### PR TITLE
Fix typo in binned likelihood docs.

### DIFF
--- a/docs/binned_likelihood.md
+++ b/docs/binned_likelihood.md
@@ -57,7 +57,7 @@ def NLL(dynamic_params, static_params, hists, observation):
     ).sum()
 
     # second product of Eq. 1 (constraint)
-    constraints = evm.loss.get_log_probs(model)
+    constraints = evm.loss.get_log_probs(params)
     # for parameters with `.value.size > 1` (jnp.sum the constraints)
     constraints = jax.tree.map(jnp.sum, constraints)
     loss_val += evm.util.sum_over_leaves(constraints)


### PR DESCRIPTION
Hey!

This is kind of a one-liner fix for the documentation. I was following the likelihood construction docs and stumbled upon this little left-over from using `eqx.Module`'s rather than functions ;)