### PR TITLE
fix: Defer prior init for NormalParameter.

### DIFF
--- a/src/evermore/parameter.py
+++ b/src/evermore/parameter.py
@@ -104,7 +104,9 @@ class NormalParameter(Parameter):
         prior (PDFLike | None): The prior distribution of the parameter, defaulting to a Normal distribution with mean 0.0 and width 1.0.
     """
 
-    prior: PDFLike | None = eqx.field(default_factory=lambda: Normal(mean=0.0, width=1.0))
+    prior: PDFLike | None = eqx.field(
+        default_factory=lambda: Normal(mean=0.0, width=1.0)
+    )
 
     def scale_log(self, up: ArrayLike, down: ArrayLike) -> Modifier:
         """

--- a/src/evermore/parameter.py
+++ b/src/evermore/parameter.py
@@ -104,7 +104,7 @@ class NormalParameter(Parameter):
         prior (PDFLike | None): The prior distribution of the parameter, defaulting to a Normal distribution with mean 0.0 and width 1.0.
     """
 
-    prior: PDFLike | None = Normal(mean=0.0, width=1.0)
+    prior: PDFLike | None = eqx.field(default_factory=lambda: Normal(mean=0.0, width=1.0))
 
     def scale_log(self, up: ArrayLike, down: ArrayLike) -> Modifier:
         """


### PR DESCRIPTION
This PR changes the default value of the `prior` class member to use a default_factory rather than a singleton `Normal(mean=0.0, width=1.0)`.

The current choice causes the singleton to be created once before users have the chance to configure the default precision via `jax.config.update("jax_enable_x64", True)`.

For me, this resulted in mixed precision operations between f32 and f64 arrays that lead to minor numerical differences (e.g. log_probs not being exactly 0 in test cases with default prior settings).