### PR TITLE
feat: Add option to shift mode in Poisson pdf.

### DIFF
--- a/src/evermore/pdf.py
+++ b/src/evermore/pdf.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-from jax.scipy.special import gammaln, xlogy
+from jax.scipy.special import gammaln, xlogy, digamma
 from jaxtyping import Array, PRNGKeyArray
 
 from evermore.util import atleast_1d_float_array
@@ -29,8 +29,8 @@ class PDF(eqx.Module, SupportsTreescope):
     @abstractmethod
     def sample(self, key: PRNGKeyArray) -> Array: ...
 
-    def prob(self, x: Array) -> Array:
-        return jnp.exp(self.log_prob(x))
+    def prob(self, x: Array, **kwargs) -> Array:
+        return jnp.exp(self.log_prob(x, **kwargs))
 
 
 class Normal(PDF):
@@ -52,15 +52,21 @@ class Normal(PDF):
 class Poisson(PDF):
     lamb: Array = eqx.field(converter=atleast_1d_float_array)
 
-    def log_prob(self, x: Array, normalize: bool = True) -> Array:
+    def log_prob(self, x: Array, normalize: bool = True, shift_mode: bool = False) -> Array:
+        # optionally adjust lambda to a higer value such that the new mode is the current lambda
+        lamb = jnp.exp(digamma(self.lamb + 1)) if shift_mode else self.lamb
+
         def _continous_poisson_log_prob(x, lamb):
             x = jnp.array(x, jnp.result_type(float))
             return xlogy(x, lamb) - lamb - gammaln(x + 1)
 
-        unnormalized = _continous_poisson_log_prob(x, self.lamb)
+        unnormalized = _continous_poisson_log_prob(x, lamb)
+
         if normalize:
-            logpdf_max = _continous_poisson_log_prob(x, x)
+            args = (self.lamb, lamb) if shift_mode else (x, x)
+            logpdf_max = _continous_poisson_log_prob(*args)
             return unnormalized - logpdf_max
+
         return unnormalized
 
     def sample(self, key: PRNGKeyArray) -> Array:

--- a/src/evermore/pdf.py
+++ b/src/evermore/pdf.py
@@ -55,7 +55,7 @@ class Poisson(PDF):
     def log_prob(
         self, x: Array, normalize: bool = True, shift_mode: bool = False
     ) -> Array:
-        # optionally adjust lambda to a higer value such that the new mode is the current lambda
+        # optionally adjust lambda to a higher value such that the new mode is the current lambda
         lamb = jnp.exp(digamma(self.lamb + 1)) if shift_mode else self.lamb
 
         def _continous_poisson_log_prob(x, lamb):

--- a/src/evermore/pdf.py
+++ b/src/evermore/pdf.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-from jax.scipy.special import gammaln, xlogy, digamma
+from jax.scipy.special import digamma, gammaln, xlogy
 from jaxtyping import Array, PRNGKeyArray
 
 from evermore.util import atleast_1d_float_array
@@ -52,7 +52,9 @@ class Normal(PDF):
 class Poisson(PDF):
     lamb: Array = eqx.field(converter=atleast_1d_float_array)
 
-    def log_prob(self, x: Array, normalize: bool = True, shift_mode: bool = False) -> Array:
+    def log_prob(
+        self, x: Array, normalize: bool = True, shift_mode: bool = False
+    ) -> Array:
         # optionally adjust lambda to a higer value such that the new mode is the current lambda
         lamb = jnp.exp(digamma(self.lamb + 1)) if shift_mode else self.lamb
 


### PR DESCRIPTION
This PR adds an option to the Poisson pdf evaluation to shift the distribution such that the pdf value at the expectation value corresponds to the maximum value, i.e., the mode.

This can come in handy when performing bias tests in maximum likelihood fits.