### PR TITLE
feat: Pass-through shape to pdf sampling.

### DIFF
--- a/src/evermore/pdf.py
+++ b/src/evermore/pdf.py
@@ -6,6 +6,7 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 from jax.scipy.special import digamma, gammaln, xlogy
+from jax._src.random import Shape
 from jaxtyping import Array, PRNGKeyArray
 
 from evermore.util import atleast_1d_float_array
@@ -30,7 +31,7 @@ class PDF(eqx.Module, SupportsTreescope):
     def scale_std(self, value: Array) -> Array: ...
 
     @abstractmethod
-    def sample(self, key: PRNGKeyArray) -> Array: ...
+    def sample(self, key: PRNGKeyArray, shape: Shape | None = None) -> Array: ...
 
     def prob(self, x: Array, **kwargs) -> Array:
         return jnp.exp(self.log_prob(x, **kwargs))
@@ -51,9 +52,12 @@ class Normal(PDF):
         # normal scaling via mean and width
         return self.mean + self.width * value
 
-    def sample(self, key: PRNGKeyArray) -> Array:
+    def sample(self, key: PRNGKeyArray, shape: Shape | None = None) -> Array:
+        # jax.random.normal does not accept None shape
+        if shape is None:
+            shape = ()
         # sample parameter from pdf
-        return self.scale_std(jax.random.normal(key))
+        return self.scale_std(jax.random.normal(key, shape=shape))
 
 
 class Poisson(PDF):
@@ -82,6 +86,9 @@ class Poisson(PDF):
         err = f"{self.__class__.__name__} does not support scale_std"
         raise Exception(err)
 
-    def sample(self, key: PRNGKeyArray) -> Array:
+    def sample(self, key: PRNGKeyArray, shape: Shape | None = None) -> Array:
+        # jax.random.poisson does not accept empty tuple shape
+        if shape == ():
+            shape = None
         # this samples only integers, do we want that?
-        return jax.random.poisson(key, self.lamb)
+        return jax.random.poisson(key, self.lamb, shape=shape)

--- a/src/evermore/pdf.py
+++ b/src/evermore/pdf.py
@@ -5,8 +5,8 @@ from abc import abstractmethod
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-from jax.scipy.special import digamma, gammaln, xlogy
 from jax._src.random import Shape
+from jax.scipy.special import digamma, gammaln, xlogy
 from jaxtyping import Array, PRNGKeyArray
 
 from evermore.util import atleast_1d_float_array


### PR DESCRIPTION
I was playing with the pdf sampling and noticed that the shape argument could be useful to pass through, which I added in this PR. This allows batched sampling given N means/lambdas and M random values created.

I imported the Shape type from [`jax._src`](https://github.com/jax-ml/jax/blob/766e68c4813a30e29b4fcefaa3253a42d0e197be/jax/_src/random.py#L58) as it's not exposed to the public API.

---

Side note: Only after seeing the sampling results for my Poisson pdf, I realized that the sampling produces only integers by construction of jax.random.poisson. I can check if we can perform some kind of "inverse transform sampling" of the continuous extension.