### PR TITLE
feat: Split Poisson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,7 +87,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
@@ -182,3 +182,4 @@ pyrightconfig.json
 # pixi environments
 .pixi
 *.egg-info
+some_filename.eqx

--- a/examples/grad_nll.py
+++ b/examples/grad_nll.py
@@ -10,7 +10,7 @@ def loss(model, hists, observation):
     expectations = model(hists)
     constraints = evm.loss.get_log_probs(model)
     loss_val = (
-        evm.pdf.Poisson(lamb=evm.util.sum_over_leaves(expectations))
+        evm.pdf.PoissonContinuous(lamb=evm.util.sum_over_leaves(expectations))
         .log_prob(
             observation,
         )

--- a/examples/nll_fit.py
+++ b/examples/nll_fit.py
@@ -16,7 +16,7 @@ def loss(dynamic_model, static_model, hists, observation):
     expectations = model(hists)
     constraints = evm.loss.get_log_probs(model)
     loss_val = (
-        evm.pdf.Poisson(evm.util.sum_over_leaves(expectations))
+        evm.pdf.PoissonContinuous(evm.util.sum_over_leaves(expectations))
         .log_prob(observation)
         .sum()
     )

--- a/examples/nll_profiling.py
+++ b/examples/nll_profiling.py
@@ -30,7 +30,7 @@ def fixed_mu_fit(mu: Array) -> Array:
         expectations = model(hists)
         constraints = evm.loss.get_log_probs(model)
         loss_val = (
-            evm.pdf.Poisson(lamb=evm.util.sum_over_leaves(expectations))
+            evm.pdf.PoissonContinuous(lamb=evm.util.sum_over_leaves(expectations))
             .log_prob(observation)
             .sum()
         )

--- a/examples/toy_generation.py
+++ b/examples/toy_generation.py
@@ -34,7 +34,7 @@ expectations = toy_expectation_vec(keys, model, hists)
 
 
 # just sample observations with poisson
-poisson_obs = evm.pdf.Poisson(observation)
+poisson_obs = evm.pdf.PoissonContinuous(observation)
 sampled_observation = poisson_obs.sample(key)
 
 # vectorized sampling

--- a/examples/toy_generation.py
+++ b/examples/toy_generation.py
@@ -34,7 +34,7 @@ expectations = toy_expectation_vec(keys, model, hists)
 
 
 # just sample observations with poisson
-poisson_obs = evm.pdf.PoissonContinuous(observation)
+poisson_obs = evm.pdf.PoissonDiscrete(observation)
 sampled_observation = poisson_obs.sample(key)
 
 # vectorized sampling

--- a/src/evermore/binned/modifier.py
+++ b/src/evermore/binned/modifier.py
@@ -139,7 +139,7 @@ class Modifier(ModifierBase):
 
         # poisson effect
         hist = jnp.array([10, 20, 30])
-        parameter = evm.Parameter(value=1.0, prior=evm.pdf.Poisson(lamb=hist))
+        parameter = evm.Parameter(value=1.0, prior=evm.pdf.PoissonDiscrete(lamb=hist))
         modify = evm.Modifier(parameter=parameter, effect=evm.effect.Linear(offset=1, slope=1))
         # or shorthand
         modify = norm.scale(offset=1, slope=1)

--- a/src/evermore/binned/staterror.py
+++ b/src/evermore/binned/staterror.py
@@ -49,7 +49,7 @@ class StatErrors(eqx.Module, SupportsTreescope):
         )
 
         # Create a modifier for the qcd process, `getter` is a function
-        # that finds the corresponding parameter from for the Poissons and Gaussians
+        # that finds the corresponding gaussian parameter
         getter = itemgetter("qcd")
         mod = staterrors.modifier(getter=getter)
         # apply the modifier to the parameter

--- a/src/evermore/loss.py
+++ b/src/evermore/loss.py
@@ -1,10 +1,8 @@
-from typing import cast
-
 import jax.numpy as jnp
 from jaxtyping import Array, PyTree
 
 from evermore.parameters.parameter import Parameter, _params_map
-from evermore.pdf import PDFLike
+from evermore.pdf import PDF
 
 __all__ = [
     "get_log_probs",
@@ -34,11 +32,12 @@ def get_log_probs(params: PyTree) -> PyTree:
 
     def _constraint(param: Parameter) -> Array:
         prior = param.prior
-        if isinstance(prior, PDFLike):
-            prior = cast(PDFLike, prior)
-            x = prior.param_to_pdf(param.value)
-            return prior.log_prob(x)
-        return jnp.array([0.0])
+        if prior is None:
+            return jnp.array([0.0])
+
+        assert isinstance(prior, PDF), f"Prior must be a PDF object, got {type(prior)}"
+        x = prior.param_to_pdf(param.value)
+        return prior.log_prob(x)
 
     # constraints from pdfs
     return _params_map(_constraint, params)

--- a/src/evermore/loss.py
+++ b/src/evermore/loss.py
@@ -36,7 +36,7 @@ def get_log_probs(params: PyTree) -> PyTree:
         prior = param.prior
         if isinstance(prior, PDFLike):
             prior = cast(PDFLike, prior)
-            x = prior.scale_std(param.value)
+            x = prior.param_to_pdf(param.value)
             return prior.log_prob(x)
         return jnp.array([0.0])
 

--- a/src/evermore/parameters/parameter.py
+++ b/src/evermore/parameters/parameter.py
@@ -7,7 +7,7 @@ import equinox as eqx
 import jax
 from jaxtyping import Array, ArrayLike, PyTree
 
-from evermore.pdf import Normal, PDFLike
+from evermore.pdf import PDF, Normal
 from evermore.util import atleast_1d_float_array, filter_tree_map
 from evermore.visualization import SupportsTreescope
 
@@ -38,7 +38,7 @@ class Parameter(eqx.Module, SupportsTreescope):
         name (str | None): An optional name for the parameter.
         lower (Array | None): The lower boundary of the parameter.
         upper (Array | None): The upper boundary of the parameter.
-        prior (PDFLike | None): The prior distribution of the parameter.
+        prior (PDF | None): The prior distribution of the parameter.
         frozen (bool): Indicates if the parameter is frozen during optimization.
         transform (ParameterTransformation | None): An optional transformation applied to the parameter.
 
@@ -60,7 +60,7 @@ class Parameter(eqx.Module, SupportsTreescope):
     name: str | None = eqx.field(static=True, default=None)
     lower: Array | None = eqx.field(default=None)
     upper: Array | None = eqx.field(default=None)
-    prior: PDFLike | None = eqx.field(default=None)
+    prior: PDF | None = eqx.field(default=None)
     frozen: bool = eqx.field(static=True, default=False)
     transform: ParameterTransformation | None = eqx.field(default=None)
 
@@ -92,12 +92,10 @@ class NormalParameter(Parameter):
     It also provides additional methods for scaling and morphing the parameter.
 
     Attributes:
-        prior (PDFLike | None): The prior distribution of the parameter, defaulting to a Normal distribution with mean 0.0 and width 1.0.
+        prior (PDF | None): The prior distribution of the parameter, defaulting to a Normal distribution with mean 0.0 and width 1.0.
     """
 
-    prior: PDFLike | None = eqx.field(
-        default_factory=lambda: Normal(mean=0.0, width=1.0)
-    )
+    prior: PDF | None = eqx.field(default_factory=lambda: Normal(mean=0.0, width=1.0))
 
     def scale_log(self, up: ArrayLike, down: ArrayLike) -> Modifier:
         """

--- a/src/evermore/parameters/sample.py
+++ b/src/evermore/parameters/sample.py
@@ -8,7 +8,7 @@ import jax.numpy as jnp
 from jaxtyping import Array, PRNGKeyArray
 
 from evermore.parameters.parameter import Parameter, _ParamsTree, is_parameter
-from evermore.pdf import PDFLike, Poisson
+from evermore.pdf import PDFLike, PoissonBase
 
 __all__ = [
     "sample_uncorrelated",
@@ -51,7 +51,7 @@ def sample_uncorrelated(params: _ParamsTree, key: PRNGKeyArray) -> _ParamsTree:
             sampled_value = pdf.sample(key.value)
 
             # TODO: Make this compatible with externally provided Poisson PDFs
-            if isinstance(pdf, Poisson):
+            if isinstance(pdf, PoissonBase):
                 sampled_value = (sampled_value / pdf.lamb) - 1
         else:
             assert param.prior is None, f"Unknown prior type: {param.prior}."

--- a/src/evermore/parameters/sample.py
+++ b/src/evermore/parameters/sample.py
@@ -8,7 +8,7 @@ import jax.numpy as jnp
 from jaxtyping import Array, PRNGKeyArray
 
 from evermore.parameters.parameter import Parameter, _ParamsTree, is_parameter
-from evermore.pdf import PDFLike, PoissonBase
+from evermore.pdf import PDF, PoissonBase
 
 __all__ = [
     "sample_uncorrelated",
@@ -43,9 +43,9 @@ def sample_uncorrelated(params: _ParamsTree, key: PRNGKeyArray) -> _ParamsTree:
     keys_tree = jax.tree.unflatten(params_structure, keys)
 
     def _sample(param: Parameter, key: Parameter) -> Array:
-        if isinstance(param.prior, PDFLike):
+        if isinstance(param.prior, PDF):
             pdf = param.prior
-            pdf = cast(PDFLike, pdf)
+            pdf = cast(PDF, pdf)
 
             # Sample new value from the prior pdf
             sampled_value = pdf.sample(key.value)

--- a/src/evermore/pdf.py
+++ b/src/evermore/pdf.py
@@ -16,7 +16,9 @@ from evermore.visualization import SupportsTreescope
 __all__ = [
     "PDF",
     "Normal",
-    "Poisson",
+    "PoissonBase",
+    "PoissonContinuous",
+    "PoissonDiscrete",
 ]
 
 
@@ -39,7 +41,10 @@ class PDF(eqx.Module, SupportsTreescope):
     def log_prob(self, x: Array) -> Array: ...
 
     @abc.abstractmethod
-    def scale_std(self, value: Array) -> Array: ...
+    def param_to_pdf(self, value: Array) -> Array: ...
+
+    @abc.abstractmethod
+    def pdf_to_param(self, x: Array) -> Array: ...
 
     @abc.abstractmethod
     def sample(self, key: PRNGKeyArray, shape: Shape | None = None) -> Array: ...
@@ -59,20 +64,76 @@ class Normal(PDF):
         unnormalized = jax.scipy.stats.norm.logpdf(x, loc=self.mean, scale=self.width)
         return unnormalized - logpdf_max
 
-    def scale_std(self, value: Array) -> Array:
+    def param_to_pdf(self, value: Array) -> Array:
         # normal scaling via mean and width
         return self.mean + self.width * value
+
+    def pdf_to_param(self, x: Array) -> Array:
+        return (x - self.mean) / self.width
 
     def sample(self, key: PRNGKeyArray, shape: Shape | None = None) -> Array:
         # jax.random.normal does not accept None shape
         if shape is None:
             shape = ()
         # sample parameter from pdf
-        return self.scale_std(jax.random.normal(key, shape=shape))
+        return self.param_to_pdf(jax.random.normal(key, shape=shape))
 
 
-class Poisson(PDF):
+class PoissonBase(PDF):
     lamb: Array = eqx.field(converter=atleast_1d_float_array)
+
+
+class PoissonDiscrete(PoissonBase):
+    """
+    Poisson distribution with discrete support. Float inputs are floored to the nearest integer.
+    See https://root.cern.ch/doc/master/RooPoisson_8cxx_source.html#l00057 for reference.
+    """
+
+    def log_prob(self, x: Array, normalize: bool = True) -> Array:
+        x = jnp.floor(x)
+
+        unnormalized = jax.scipy.stats.poisson.pmf(x, self.lamb)
+        if not normalize:
+            return unnormalized
+
+        logpdf_max = jax.scipy.stats.poisson.pmf(x, x)
+        return unnormalized - logpdf_max
+
+    def param_to_pdf(self, value: Array) -> Array:
+        # convert the value to a normal cdf value to look for
+        target_cdf = jax.scipy.stats.norm.cdf(value)
+
+        # perform an iterative search
+        # see: https://num.pyro.ai/en/stable/tutorials/truncated_distributions.html?highlight=poisson%20inverse#5.3-Example:-Left-truncated-Poisson
+        def cond_fn(val):
+            n, cdf = val
+            return jnp.any(cdf < target_cdf)
+
+        def body_fn(val):
+            n, cdf = val
+            n_new = jnp.where(cdf < target_cdf, n + 1, n)
+            return n_new, jax.scipy.stats.poisson.cdf(n_new, self.lamb)
+
+        start_n = jnp.zeros_like(value, dtype=jnp.result_type(int))
+        start_cdf = jnp.zeros_like(value, dtype=jnp.result_type(float))
+        n, _ = jax.lax.while_loop(cond_fn, body_fn, (start_n, start_cdf))
+
+        # since we check for cdf < value, n will always refer to the next value
+        return jnp.clip(n - 1, min=0)
+
+    def pdf_to_param(self, x: Array) -> Array:
+        x = jnp.floor(x)
+        cdf = jax.scipy.stats.poisson.cdf(x, self.lamb)
+        return jax.scipy.stats.norm.ppf(cdf)
+
+    def sample(self, key: PRNGKeyArray, shape: Shape | None = None) -> Array:
+        # jax.random.poisson does not accept empty tuple shape
+        if shape == ():
+            shape = None
+        return jax.random.poisson(key, self.lamb, shape=shape)
+
+
+class PoissonContinuous(PoissonBase):
 
     def log_prob(
         self, x: Array, normalize: bool = True, shift_mode: bool = False
@@ -80,26 +141,26 @@ class Poisson(PDF):
         # optionally adjust lambda to a higher value such that the new mode is the current lambda
         lamb = jnp.exp(digamma(self.lamb + 1)) if shift_mode else self.lamb
 
-        def _continous_poisson_log_prob(x, lamb):
+        def _log_prob(x, lamb):
             x = jnp.array(x, jnp.result_type(float))
             return xlogy(x, lamb) - lamb - gammaln(x + 1)
 
-        unnormalized = _continous_poisson_log_prob(x, lamb)
+        unnormalized = _log_prob(x, lamb)
+        if not normalize:
+            return unnormalized
 
-        if normalize:
-            args = (self.lamb, lamb) if shift_mode else (x, x)
-            logpdf_max = _continous_poisson_log_prob(*args)
-            return unnormalized - logpdf_max
+        args = (self.lamb, lamb) if shift_mode else (x, x)
+        logpdf_max = _log_prob(*args)
+        return unnormalized - logpdf_max
 
-        return unnormalized
+    def param_to_pdf(self, value: Array) -> Array:
+        err = f"{self.__class__.__name__} does not support param_to_pdf"
+        raise Exception(err)
 
-    def scale_std(self, value: Array) -> Array:
-        err = f"{self.__class__.__name__} does not support scale_std"
+    def pdf_to_param(self, x: Array) -> Array:
+        err = f"{self.__class__.__name__} does not support pdf_to_param"
         raise Exception(err)
 
     def sample(self, key: PRNGKeyArray, shape: Shape | None = None) -> Array:
-        # jax.random.poisson does not accept empty tuple shape
-        if shape == ():
-            shape = None
-        # this samples only integers, do we want that?
-        return jax.random.poisson(key, self.lamb, shape=shape)
+        msg = f"{self.__class__.__name__} does not support sampling, use PoissonDiscrete instead"
+        raise Exception(msg)

--- a/src/evermore/pdf.py
+++ b/src/evermore/pdf.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import abc
-from typing import Protocol, runtime_checkable
 
 import equinox as eqx
 import jax
@@ -24,16 +23,6 @@ __all__ = [
 
 def __dir__():
     return __all__
-
-
-@runtime_checkable
-class PDFLike(Protocol):
-    """Mirrors the (relevant) interface of `tfp.distributions.Distribution` & `distrax.Distribution`."""
-
-    def log_prob(self, x: Array) -> Array: ...
-    def scale_std(self, value: Array) -> Array: ...
-    def sample(self, key: PRNGKeyArray) -> Array: ...
-    def prob(self, x: Array) -> Array: ...
 
 
 class PDF(eqx.Module, SupportsTreescope):
@@ -134,7 +123,6 @@ class PoissonDiscrete(PoissonBase):
 
 
 class PoissonContinuous(PoissonBase):
-
     def log_prob(
         self, x: Array, normalize: bool = True, shift_mode: bool = False
     ) -> Array:

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import jax.numpy as jnp
 import pytest
 
-from evermore.pdf import Normal, Poisson
+from evermore.pdf import Normal, PoissonContinuous, PoissonDiscrete
 
 
 def test_Normal():
@@ -12,7 +12,13 @@ def test_Normal():
     assert pdf.log_prob(jnp.array(0.0)) == pytest.approx(0.0)
 
 
-def test_Poisson():
-    pdf = Poisson(lamb=jnp.array(10))
+def test_PoissonDiscrete():
+    pdf = PoissonDiscrete(lamb=jnp.array(10))
+
+    assert pdf.log_prob(jnp.array(5.0)) == pytest.approx(-1.5342636)
+
+
+def test_PoissonContinuous():
+    pdf = PoissonContinuous(lamb=jnp.array(10))
 
     assert pdf.log_prob(jnp.array(5.0)) == pytest.approx(-1.5342636)


### PR DESCRIPTION
This PR splits the Poisson PDF into a discrete and a continuous version. This way, the exact choice is more transparent to the user.