### PR TITLE
feat: Use ruff in preview mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     hooks:
       - id: mypy
         files: src|tests
-        args: []
+        args: [--config-file=pyproject.toml]
         additional_dependencies:
           - pytest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,12 +101,16 @@ ignore_missing_imports = true
 
 
 [tool.ruff.lint]
+preview = true
 ignore = [
     "PLR",  # Design related pylint codes
     "E501", # Line too long
     # "B006",   # converts default args to 'None'
     "I002",   # isort: "from __future__ import annotations"
     "ISC001", # flake8-implicit-str-concat: Implicit string concatenation"
+    "PLC0415",  # `import` should be at the top-level of a file
+    "PLW3201",  # Dunder method `...` has no special meaning in Python 3
+    "RUF052",  # Local dummy variable `...` is accessed
 ]
 select = [
     "E",
@@ -130,6 +134,7 @@ select = [
     "UP",  # pyupgrade
     "YTT", # flake8-2020
     "EXE", # flake8-executable
+    "E303", # Too many blank lines
 ]
 unfixable = [
     "F841", # Would remove unused variables

--- a/src/evermore/pdf.py
+++ b/src/evermore/pdf.py
@@ -95,7 +95,7 @@ class PoissonDiscrete(PoissonBase):
         # perform an iterative search
         # see: https://num.pyro.ai/en/stable/tutorials/truncated_distributions.html?highlight=poisson%20inverse#5.3-Example:-Left-truncated-Poisson
         def cond_fn(val):
-            n, cdf = val
+            _, cdf = val
             return jnp.any(cdf < target_cdf)
 
         def body_fn(val):


### PR DESCRIPTION
I noticed that the linting and formatting performed by the current pre-commit sequence is not fully in line with the ruff rules defined in the `pyproject.toml`. To be able to get live feedback from ruff while typing, [preview mode](https://docs.astral.sh/ruff/preview) needs to be activated, adding additional rules that are not **yet** part of the main linting pass. Except for three of these additional rules, ruff is now fully compatible to the pre-commit workflow.

In detail, I disabled

- PLC0415, to allow inline imports,
- PLW3201, to allow defining custom dunder methods like `__treescope_repr__`, and
- RUF052, to allow using variable names that match the so-called "dummy pattern" with a leading underscore, i.e. `_VARNAME`.

The additional rules highlighted only a single extra issue (unused variable) that I fixed.

With the new settings, mypy now also works properly on all staged diffs as intended.

---

Side note: In my local setup that runs type checks on the full code base, I see a couple issues raised regarding mypy not being able interpret the output type of eqx's `attr: Array = eqx.field(converter=...)` feature. E.g. pytrees are initialized with members set to floats, without mypy knowing that they will be converted to 1d float arrays and complaining about the `float` ↔︎ `Array` mismatch.

This won't fix in the future (in fact, this typing ambiguity was a reason why the built-in `dataclasses.field` did not get the `converter` feature, see the rejected [PEP712](https://peps.python.org/pep-0712/)), so in a different PR I would add exclusions for the relevant lines (#49).