### PR TITLE
feat: Compute flat correlation.

### DIFF
--- a/src/evermore/loss.py
+++ b/src/evermore/loss.py
@@ -127,8 +127,6 @@ def compute_covariance(
 
     # normalize via D^-1 @ cov @ D^-1 with D being the diagnonal standard deviation matrix
     d = jnp.sqrt(jnp.diag(cov))
-
-    # normalize
     cov = cov / jnp.outer(d, d)
 
     # to avoid numerical issues, fix the diagonal to 1

--- a/src/evermore/loss.py
+++ b/src/evermore/loss.py
@@ -84,6 +84,22 @@ def compute_covariance(
     parameter values at a given loss function. The covariance is computed using the inverted Hessian
     under the Laplace assumption of normality, followed by a normalization step.
 
+    .. code-block:: python
+
+        import jax.numpy as jnp
+        import evermore as evm
+
+        params = {"a": jnp.array(2.0), "b": jnp.array(3.0), "c": jnp.array(4.0)}
+
+
+        def loss_fn(params):
+            # some loss function depending on params["a"], params["b"] and params["c"]
+            return ...
+
+
+        # compute the covariance matrix
+        cov = evm.loss.compute_covariance(loss_fn, params)
+
     Args:
         loss_fn (Callable): A callable whose gradients are evaluated for the computation.
         params (PyTree): A PyTree containing parameters to compute the covariance for.

--- a/src/evermore/loss.py
+++ b/src/evermore/loss.py
@@ -1,4 +1,3 @@
-import collections
 import typing as tp
 
 import jax
@@ -10,7 +9,7 @@ from evermore.parameters.parameter import Parameter, _params_map
 from evermore.pdf import PDF, ImplementsFromUnitNormalConversion, Normal
 
 __all__ = [
-    "compute_correlation",
+    "compute_covariance",
     "get_log_probs",
 ]
 
@@ -74,19 +73,47 @@ def get_log_probs(params: PyTree) -> PyTree:
     return _params_map(_constraint, params)
 
 
-def compute_correlation(
-    loss_fn: collections.abc.Callable,
+def compute_covariance(
+    loss_fn: tp.Callable,
     params: PyTree,
     args: tuple[tp.Any, ...] = (),
+    kwargs: dict[str, tp.Any] | None = None,
 ) -> Array:
+    """
+    Computes the covariance (correlation) matrix between parameters in a PyTree, evaluated with its
+    parameter values at a given loss function. The covariance is computed using the inverted Hessian
+    under the Laplace assumption of normality, followed by a normalization step.
+
+    Args:
+        loss_fn (Callable): A callable whose gradients are evaluated for the computation.
+        params (PyTree): A PyTree containing parameters to compute the covariance for.
+        args (tuple): Additional positional arguments to pass to the loss function.
+        kwargs (dict): Additional keyword arguments to pass to the loss function.
+
+    Returns:
+        Array: A square matrix representing the correlation between parameters.
+    """
+    # default kwargs
+    if kwargs is None:
+        kwargs = {}
+
     # create a flattened version of the parameters and the loss
     flat_params, unravel_fn = jax.flatten_util.ravel_pytree(params)
 
     def flat_loss_fn(flat_params: Array) -> float:
-        return loss_fn(unravel_fn(flat_params), *args)
+        return loss_fn(unravel_fn(flat_params), *args, **kwargs)
 
     # compute the hessian at the current parameters
     h = jax.hessian(flat_loss_fn)(flat_params)
 
-    # invert to get the correlation matrix under the Laplace assumption of normality
-    return jnp.linalg.inv(h)
+    # get the unnormalized covariance matrix
+    cov = jnp.linalg.inv(h)
+
+    # normalize via D^-1 @ cov @ D^-1 with D being the diagnonal standard deviation matrix
+    d = jnp.sqrt(jnp.diag(cov))
+
+    # normalize
+    cov = cov / jnp.outer(d, d)
+
+    # to avoid numerical issues, fix the diagonal to 1
+    return jnp.fill_diagonal(cov, 1.0, inplace=False)

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import jax.numpy as jnp
+import numpy as np
 import pytest
 
 import evermore as evm
@@ -16,3 +18,20 @@ def test_get_log_probs():
     assert log_probs["a"] == pytest.approx(-0.125)
     assert log_probs["b"] == pytest.approx(0.0)
     assert log_probs["c"] == pytest.approx(0.0)
+
+
+def test_compute_covariance():
+    def loss_fn(params):
+        return (
+            params["a"] ** 2 + 2 * params["b"] ** 2 + (params["a"] + params["c"]) ** 2
+        )
+
+    params = {"a": jnp.array(2.0), "b": jnp.array(3.0), "c": jnp.array(4.0)}
+
+    cov = evm.loss.compute_covariance(loss_fn, params)
+
+    assert cov.shape == (3, 3)
+    np.testing.assert_allclose(
+        cov,
+        jnp.array([[1.0, 0.0, -0.7071067], [0.0, 1.0, 0.0], [-0.7071067, 0.0, 1.0]]),
+    )


### PR DESCRIPTION
This PR adds a function for computing the correlation matrix. The return value is a flat, square matrix.

Should there also be (or should the only way be) a way to return a version of the params pytree with parameter combinatorics?