### PR TITLE
feat: add sampling from cov matrix

### DIFF
--- a/examples/model.py
+++ b/examples/model.py
@@ -51,26 +51,26 @@ def model(
 
 hists = {
     "nominal": {
-        "signal": jnp.array([3]),
-        "bkg1": jnp.array([10]),
-        "bkg2": jnp.array([20]),
+        "signal": jnp.array([3.0]),
+        "bkg1": jnp.array([10.0]),
+        "bkg2": jnp.array([20.0]),
     },
     "shape_up": {
-        "bkg1": jnp.array([12]),
-        "bkg2": jnp.array([23]),
+        "bkg1": jnp.array([12.0]),
+        "bkg2": jnp.array([23.0]),
     },
     "shape_down": {
-        "bkg1": jnp.array([8]),
-        "bkg2": jnp.array([19]),
+        "bkg1": jnp.array([8.0]),
+        "bkg2": jnp.array([19.0]),
     },
 }
 
 params = Params(
-    mu=evm.Parameter(value=0.0, lower=0.0, upper=10.0),  # type: ignore[arg-type]
+    mu=evm.Parameter(),  # type: ignore[arg-type]
     norm1=evm.NormalParameter(),
     norm2=evm.NormalParameter(),
     shape1=evm.NormalParameter(),
 )
 
-observation = jnp.array([37])
+observation = jnp.array([37.0])
 expectations = model(params, hists)

--- a/examples/nll_fit.py
+++ b/examples/nll_fit.py
@@ -38,12 +38,12 @@ def make_step(
     hists: PyTree[Float[Array, " nbins"]],
     observation: Float[Array, " nbins"],
 ) -> tuple[PyTree[evm.Parameter], PyTree]:
-    # differentiate full analysis
     diffable, static = evm.parameter.partition(params)
     grads = eqx.filter_grad(loss)(diffable, static, hists, observation)
     updates, opt_state = optim.update(grads, opt_state)
-    # apply nuisance parameter and DNN weight updates
-    params = eqx.apply_updates(params, updates)
+    # apply parameter updates
+    diffable = eqx.apply_updates(diffable, updates)
+    params = evm.parameter.combine(diffable, static)
     return params, opt_state
 
 

--- a/examples/nll_profiling.py
+++ b/examples/nll_profiling.py
@@ -43,12 +43,12 @@ def fixed_mu_fit(mu: Float[Array, ""]) -> Float[Array, ""]:
         hists: PyTree[Float[Array, " nbins"]],
         observation: Float[Array, " nbins"],
     ) -> tuple[PyTree[evm.Parameter], PyTree]:
-        # differentiate
         diffable, static = evm.parameter.partition(params)
         grads = eqx.filter_grad(loss)(diffable, static, hists, observation)
         updates, opt_state = optim.update(grads, opt_state)
-        # apply nuisance parameter and DNN weight updates
-        params = eqx.apply_updates(params, updates)
+        # apply parameter updates
+        diffable = eqx.apply_updates(diffable, updates)
+        params = evm.parameter.combine(diffable, static)
         return params, opt_state
 
     # minimize params with 1000 steps

--- a/examples/toy_generation.py
+++ b/examples/toy_generation.py
@@ -1,40 +1,121 @@
+import equinox as eqx
 import jax
+import jax.numpy as jnp
 from jaxtyping import Array, Float, PRNGKeyArray, PyTree
 from model import hists, model, observation, params
 
 import evermore as evm
 
-key = jax.random.PRNGKey(0)
-
-# generate a new set of params according to their constraint pdfs
-toy_params = evm.sample.sample_uncorrelated(params, key)
+key = jax.random.PRNGKey(42)
 
 
-# generate new expectation based on the toy model
+@eqx.filter_jit
+def loss(
+    diffable: PyTree[evm.Parameter],
+    static: PyTree[evm.Parameter],
+    hists: PyTree[Float[Array, " nbins"]],
+    observation: Float[Array, " nbins"],
+) -> Float[Array, ""]:
+    params = evm.parameter.combine(diffable, static)
+    expectations = model(params, hists)
+    constraints = evm.loss.get_log_probs(params)
+    loss_val = (
+        evm.pdf.PoissonContinuous(evm.util.sum_over_leaves(expectations))
+        .log_prob(observation)
+        .sum()
+    )
+    # add constraint
+    loss_val += evm.util.sum_over_leaves(constraints)
+    return -jnp.sum(loss_val)
+
+
+# --- Postfit sampling ---
+# use the following for correlated (postfit) sampling
+# (the following creates a Covariance matrix based the number of parameter in an arbitrary pytree)
+
+# First we have to optimize of course out parameters, let's copy & past from examples/nll_fit.py
+import optax  # noqa: E402
+
+optim = optax.sgd(learning_rate=1e-2)
+opt_state = optim.init(eqx.filter(model, eqx.is_inexact_array))
+
+
+@eqx.filter_jit
+def make_step(
+    params: PyTree[evm.Parameter],
+    opt_state: PyTree,
+    hists: PyTree[Float[Array, " nbins"]],
+    observation: Float[Array, " nbins"],
+) -> tuple[PyTree[evm.Parameter], PyTree]:
+    # differentiate full analysis
+    diffable, static = evm.parameter.partition(params)
+    grads = eqx.filter_grad(loss)(diffable, static, hists, observation)
+    updates, opt_state = optim.update(grads, opt_state)
+    # apply nuisance parameter and DNN weight updates
+    params = eqx.apply_updates(params, updates)
+    return params, opt_state
+
+
+# minimize params with 3.000 steps
+for step in range(3_000):
+    if step % 500 == 0:
+        diffable, static = evm.parameter.partition(params)
+        loss_val = loss(diffable, static, hists, observation)
+        print(f"{step=} - {loss_val=:.6f}")
+    params, opt_state = make_step(params, opt_state, hists, observation)
+
+diffable, static = evm.parameter.partition(params)
+fast_covariance_matrix = eqx.filter_jit(evm.sample.compute_covariance_matrix)
+covariance_matrix = fast_covariance_matrix(
+    loss=loss,
+    params=diffable,
+    args=(static, hists, observation),
+)
+
+
+# --- Prefit sampling ---
+# use the following instead of the code above for decorrelated (prefit) sampling:
+# (the following creates a Identity matrix based the number of parameter in an arbitrary pytree)
+# values = jax.tree.map(lambda p: p.value, params, is_leaf=evm.parameter.is_parameter)
+# flat_values, _ = jax.flatten_util.ravel_pytree(values)
+# covariance_matrix = jnp.eye(flat_values.shape[0])
+
+
+# generate new expectation based on the toy parameters
+# @eqx.filter_jit
 def toy_expectation(
     key: PRNGKeyArray,
     params: PyTree[evm.Parameter],
-    hists: PyTree[Float[Array, " nbins"]],
+    *,
+    n_samples: int = 1,
 ) -> Float[Array, " nbins"]:
-    toy_params = evm.sample.sample_uncorrelated(params, key)
+    toy_params = evm.sample.sample_from_covariance_matrix(
+        key=key,
+        params=params,
+        covariance_matrix=covariance_matrix,
+        n_samples=n_samples,
+    )
     expectations = model(toy_params, hists)
     return evm.util.sum_over_leaves(expectations)
 
 
-expectation = toy_expectation(key, params, hists)
+print("Exp.:", evm.util.sum_over_leaves(model(params, hists)))
+print("Obs.:", observation)
 
+# create 1 toy
+expectation = toy_expectation(key, params)
+print("1 toy:", expectation)
 
-# generate a new expectations vectorized over many keys
-keys = jax.random.split(key, 1000)
-
-# vectorized toy expectation
-toy_expectation_vec = jax.vmap(toy_expectation, in_axes=(0, None, None))
-expectations = toy_expectation_vec(keys, params, hists)
+# vectorized toy expectation for 10k toys
+expectations = toy_expectation(key, params, n_samples=10_000)
+print("Mean of 10.000 toys:", jnp.mean(expectations, axis=0))
+print("Std of 10.000 toys:", jnp.std(expectations, axis=0))
 
 
 # just sample observations with poisson
 poisson_obs = evm.pdf.PoissonDiscrete(observation)
 sampled_observation = poisson_obs.sample(key)
 
-# vectorized sampling
+# vectorized sampling (generically with `vmap`)
+keys = jax.random.split(key, 10_000)
 sampled_observations = jax.vmap(poisson_obs.sample)(keys)

--- a/src/evermore/parameters/sample.py
+++ b/src/evermore/parameters/sample.py
@@ -5,22 +5,35 @@ import typing as tp
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-from jaxtyping import Array, Float
+from jaxtyping import Array, Float, PRNGKeyArray
 
 from evermore.parameters.parameter import (
+    Parameter,
     _params_map,
     _ParamsTree,
     is_parameter,
 )
+from evermore.pdf import PDF, PoissonBase
+from evermore.util import _missing
 
 __all__ = [
     "compute_covariance_matrix",
     "sample_from_covariance_matrix",
+    "sample_from_priors",
 ]
 
 
 def __dir__():
     return __all__
+
+
+def _replace_param_value(
+    param: Parameter,
+    value: Float[Array, ...],
+) -> Parameter:
+    if param.value is _missing:
+        return param
+    return eqx.tree_at(lambda p: p.value, param, value)
 
 
 def compute_covariance_matrix(
@@ -29,6 +42,38 @@ def compute_covariance_matrix(
     *,
     args: tuple[tp.Any, ...] = (),
 ) -> Float[Array, "nparams nparams"]:
+    """
+    Computes the covariance matrix of the parameters under the Laplace approximation,
+    by inverting the Hessian of the loss function at the current parameter values.
+
+    See examples/toy_generation.py for an example usage.
+
+    Args:
+        loss (Callable): The loss function. Should accept (params, *args) as arguments.
+        params (_ParamsTree): A PyTree of parameters.
+        args (tuple, optional): Additional arguments to pass to the loss function.
+
+    Returns:
+        Float[Array, "nparams nparams"]: The covariance matrix of the parameters.
+
+    Example:
+        >>> import evermore as evm
+        >>> import jax
+        >>> import jax.numpy as jnp
+        >>>
+        >>>
+        >>> def loss_fn(params):
+        ...     x = params["a"].value
+        ...     y = params["b"].value
+        ...     return jnp.sum((x - 1.0) ** 2 + (y - 2.0) ** 2)
+        >>> params = {
+        ...     "a": evm.Parameter(value=jnp.array([1.0]), prior=None, lower=0.0, upper=2.0),
+        ...     "b": evm.Parameter(value=jnp.array([2.0]), prior=None, lower=1.0, upper=3.0),
+        ... }
+        >>> cov = evm.sample.compute_covariance_matrix(loss_fn, params)
+        >>> cov.shape
+        (2, 2)
+    """
     # first, compute the hessian at the current point
     values = _params_map(lambda p: p.value, params)
     flat_values, unravel_fn = jax.flatten_util.ravel_pytree(values)
@@ -36,11 +81,8 @@ def compute_covariance_matrix(
     def _flat_loss(flat_values: Float[Array, ...]) -> Float[Array, ""]:
         param_values = unravel_fn(flat_values)
 
-        def _replace_value(param, value):
-            return eqx.tree_at(lambda p: p.value, param, value)
-
         _params = jax.tree.map(
-            _replace_value, params, param_values, is_leaf=is_parameter
+            _replace_param_value, params, param_values, is_leaf=is_parameter
         )
         return loss(_params, *args)
 
@@ -58,29 +100,115 @@ def sample_from_covariance_matrix(
     covariance_matrix: Float[Array, "nparams nparams"],
     n_samples: int = 1,
 ) -> _ParamsTree:
+    """
+    Samples parameter sets from a multivariate normal distribution defined by the given covariance matrix,
+    centered around the current parameter values.
+
+    See examples/toy_generation.py for an example usage.
+
+    Args:
+        key (jax.random.PRNGKey): A JAX random key used for generating random samples.
+        params (_ParamsTree): A PyTree of parameters whose values will be used as the mean of the distribution.
+        covariance_matrix (Float[Array, "nparams nparams"]): The covariance matrix for the multivariate normal distribution.
+        n_samples (int, optional): The number of samples to draw. Defaults to 1.
+
+    Returns:
+        _ParamsTree: A PyTree with the same structure as `params`, where each parameter value is replaced
+        by a sampled value. If `n_samples > 1`, the parameter values will have a batch dimension as the first axis.
+
+    Example:
+        >>> import evermore as evm
+        >>> import jax
+        >>> import jax.numpy as jnp
+        >>>
+        >>>
+        >>> param1 = evm.Parameter(value=jnp.array([1.0]), prior=None, lower=0.0, upper=2.0)
+        >>> param2 = evm.Parameter(value=jnp.array([2.0]), prior=None, lower=1.0, upper=3.0)
+        >>> params = {"a": param1, "b": param2}
+        >>> cov = jnp.array([[1.0, 0.5], [0.5, 2.0]])
+        >>> key = jax.random.PRNGKey(0)
+        >>> sampled = evm.sample.sample_from_covariance_matrix(key, params, covariance_matrix=cov, n_samples=3)
+        >>> sampled["a"].value.shape
+        (3, 1)
+        >>> sampled["b"].value.shape
+        (3, 1)
+    """
     # get the value & make sure it has at least 1d so we insert a batch dim later
-    values = _params_map(lambda p: jnp.atleast_1d(p.value), params)
+    values = _params_map(
+        lambda p: _missing if p.value is _missing else jnp.atleast_1d(p.value), params
+    )
     flat_values, unravel_fn = jax.flatten_util.ravel_pytree(values)
 
-    # sample parameter sets from the correlation matrix
-    # note that the sampling should be centered around the current parameters,
-    # but 0 is chosen here since they are used as offsets
-    flat_sampled_offsets = jax.random.multivariate_normal(
+    # sample parameter sets from the correlation matrix (centered around `flat_values`)
+    flat_sampled_values = jax.random.multivariate_normal(
         key=key,
-        mean=jnp.zeros_like(flat_values),
+        mean=flat_values,
         cov=covariance_matrix,
         shape=(n_samples,),
     )
 
     # insert batch dim
-    sampled_param_values = jax.vmap(unravel_fn, in_axes=(0,))(
-        flat_values + flat_sampled_offsets
-    )
+    sampled_param_values = jax.vmap(unravel_fn)(flat_sampled_values)
 
     # put them into the original structure again
-    def _replace_value(param, value):
-        return eqx.tree_at(lambda p: p.value, param, value)
-
     return jax.tree.map(
-        _replace_value, params, sampled_param_values, is_leaf=is_parameter
+        _replace_param_value, params, sampled_param_values, is_leaf=is_parameter
     )
+
+
+def sample_from_priors(params: _ParamsTree, key: PRNGKeyArray) -> _ParamsTree:
+    """
+    Samples from the individual prior distributions of the parameters in the given PyTree.
+    Note that no correlations between parameters are taken into account during sampling.
+
+    See examples/toy_generation.py for an example usage.
+
+    Args:
+        params (_ParamsTree): A PyTree of parameters from which to sample.
+        key (PRNGKeyArray): A JAX random key used for generating random samples.
+
+    Returns:
+        _ParamsTree: A new PyTree with the parameters sampled from their respective prior distributions.
+
+    Example:
+        >>> import evermore as evm
+        >>> import jax
+        >>> import jax.numpy as jnp
+        >>>
+        >>>
+        >>> param1 = evm.Parameter(value=jnp.array([0.0]))
+        >>> param2 = evm.NormalParameter(value=jnp.array([0.0]))
+        >>> params = {"a": param1, "b": param2}
+        >>> key = jax.random.PRNGKey(0)
+        >>> sampled = evm.sample.sample_from_priors(params, key)
+        >>> sampled["a"].value.shape
+        (1,)
+        >>> sampled["b"].value.shape
+        (1,)
+    """
+    flat_params, treedef = jax.tree.flatten(params, is_leaf=is_parameter)
+    n_params = len(flat_params)
+
+    # create a key for each parameter
+    keys = jax.random.split(key, n_params)
+    keys_tree = jax.tree.unflatten(treedef, keys)
+
+    def _sample_from_prior(param: Parameter, key) -> Array:
+        if isinstance(param.prior, PDF) and param.value is not _missing:
+            pdf = param.prior
+
+            # Sample new value from the prior pdf
+            sampled_value = pdf.sample(key)
+
+            # TODO: this is not correct I assume
+            if isinstance(pdf, PoissonBase):
+                sampled_value = (sampled_value / pdf.lamb) - 1
+
+            # replace in param:
+            return eqx.tree_at(lambda p: p.value, param, sampled_value)
+        # can't sample if there's no pdf to sample from,
+        # or when the value is `_missing`
+        return param
+
+    # Sample for each parameter
+    return jax.tree.map(_sample_from_prior, params, keys_tree, is_leaf=is_parameter)

--- a/src/evermore/util.py
+++ b/src/evermore/util.py
@@ -29,6 +29,7 @@ def float_array(x: Any) -> Float[Array, ...]:
     return jnp.asarray(x, jnp.result_type(float))
 
 
+@jax.tree_util.register_static
 class _Missing:
     __slots__ = ()
 


### PR DESCRIPTION
This PR adds sampling from the cov matrix. I need to better understand if this is correct though (example/toy_generation.py):
```python
Exp.: [36.95273]
Obs.: [37.]
1 toy: [[37.855755]]
Mean of 10.000 toys: [37.694954]
Std of 10.000 toys: [6.064754]
```
I'd expect mean of 10k toys to be ~Exp. here in the postfit case. Am I doing something wrong?

edit: it seems that this may happen if we're not dealing with perfect symmetrical gaussian as the likelihood.