### PR TITLE
update flax minimum version to 0.12.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "jax>=0.7.2", # jax.new_ref
     "jaxlib",
     "jaxtyping",
-    "flax>=0.12.0",
+    "flax==0.12.1",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "jax>=0.7.2", # jax.new_ref
     "jaxlib",
     "jaxtyping",
-    "flax==0.12.1",
+    "flax>=0.12.1",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
the method `get_value` is not available in 0.12.0 of flax
so tests fail with that version, needs to be at least 0.12.1